### PR TITLE
Add support for separate TS and PHP typing paths in sync command

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ EXAMPLES
   $ figex make:config
 ```
 
-_See code: [src/commands/make/config.ts](https://github.com/4746/figex/blob/v0.0.2/src/commands/make/config.ts)_
+_See code: [src/commands/make/config.ts](https://github.com/4746/figex/blob/v0.0.3/src/commands/make/config.ts)_
 
 ## `figex sync`
 
@@ -71,18 +71,20 @@ Sync svg icons
 
 ```
 USAGE
-  $ figex sync [--fileId <value>] [--nameExportType <value>] [--page <value>] [--pathFileSprite <value>]
-    [--pathFileType <value>] [--phpNamespace <value>] [--phpUse <value>] [--showResultTable] [--silent] [--token
-    <value>]
+  $ figex sync [--fileId <value>] [--nameExportType <value>] [--pathFileTypeTS <value>] [--pathFileTypePHP
+    <value>] [--page <value>] [--pathFileSprite <value>] [--pathFileType <value>] [--phpNamespace <value>] [--phpUse
+    <value>] [--showResultTable] [--silent] [--token <value>]
 
 FLAGS
-  --fileId=<value>          Figma fileId or create env.FIGMA_FILE_ID
-  --nameExportType=<value>  Name enum .ts or .php
-  --page=<value>            ...
-  --pathFileSprite=<value>  Represents the path to a sprite svg file.
-  --pathFileType=<value>    Represents the file type of a given path.
-  --phpNamespace=<value>    The PHP namespace represents the namespace of a PHP enum file.
-  --phpUse=<value>          Extend enum via use OtherEnums
+  --fileId=<value>           Figma fileId or create env.FIGMA_FILE_ID
+  --nameExportType=<value>   Name enum .ts or .php
+  --page=<value>             ...
+  --pathFileSprite=<value>   Represents the path to a sprite svg file.
+  --pathFileType=<value>     Represents the file type of a given path.
+  --pathFileTypePHP=<value>  Name enum .php
+  --pathFileTypeTS=<value>   Name enum .ts
+  --phpNamespace=<value>     The PHP namespace represents the namespace of a PHP enum file.
+  --phpUse=<value>           Extend enum via use OtherEnums
   --showResultTable
   --silent
   --token=<value>
@@ -94,7 +96,7 @@ EXAMPLES
   $ figex sync --help
 ```
 
-_See code: [src/commands/sync.ts](https://github.com/4746/figex/blob/v0.0.2/src/commands/sync.ts)_
+_See code: [src/commands/sync.ts](https://github.com/4746/figex/blob/v0.0.3/src/commands/sync.ts)_
 <!-- commandsstop -->
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cli107/figex",
   "description": "Figma export svg",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "author": "Vadim",
   "keywords": [
     "figma-export",

--- a/src/lib/entities/conf.ts
+++ b/src/lib/entities/conf.ts
@@ -17,6 +17,8 @@ export interface IFigmaDefaultConf {
    * The path to the typing file
    */
   pathFileType?: string;
+  pathFileTypeTS?: string,
+  pathFileTypePHP?: string,
   personalToken: string,
   /**
    * The PHP namespace represents the namespace of a PHP enum file.

--- a/src/lib/svg.ts
+++ b/src/lib/svg.ts
@@ -77,6 +77,10 @@ function createEnumPHP(
 export async function createSvgTypes({buildVersion, nameExportType, names, pathFileType, phpNamespace, phpUse}: {buildVersion: string, nameExportType: string, names: string[], pathFileType: string, phpNamespace: string, phpUse: string}) {
   const PlatformPath = path.parse(pathFileType);
 
+  if (!fs.existsSync(PlatformPath.dir)) {
+    await fs.promises.mkdir(PlatformPath.dir, {recursive: true})
+  }
+
   const stat = await fs.promises.stat(PlatformPath.dir);
   if (stat.isFile()) {
     throw new Error(`is not a folder: [${PlatformPath.dir}]`);
@@ -167,6 +171,11 @@ export async function createSvgSprite({pathFileSprite, typeIcons}: {pathFileSpri
   const promiseSymbols = typeIcons.map((item => readSvgDesignSystemIcon(item)))
 
   const svgSymbols = await Promise.all(promiseSymbols);
+
+  const PlatformPath = path.parse(pathFileSprite);
+  if (!fs.existsSync(PlatformPath.dir)) {
+    await fs.promises.mkdir(PlatformPath.dir, {recursive: true})
+  }
 
   return saveSvgSprite({
     contentSymbol: svgSymbols.filter(Boolean).sort((a, b) => {


### PR DESCRIPTION
Introduces new flags `pathFileTypeTS` and `pathFileTypePHP` for specifying separate typing output paths for TypeScript and PHP files. Updated logic to handle these paths in the `sync` command and related configurations. Adjusted README, version, and error handling to reflect the updated functionality.