### PR TITLE
Bump to version 1.1.1, update README links, and implement hashed spri…

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ EXAMPLES
   $ figex make:config
 ```
 
-_See code: [src/commands/make/config.ts](https://github.com/4746/figex/blob/v1.1.0/src/commands/make/config.ts)_
+_See code: [src/commands/make/config.ts](https://github.com/4746/figex/blob/v1.1.1/src/commands/make/config.ts)_
 
 ## `figex sync`
 
@@ -97,7 +97,7 @@ EXAMPLES
   $ figex sync --help
 ```
 
-_See code: [src/commands/sync.ts](https://github.com/4746/figex/blob/v1.1.0/src/commands/sync.ts)_
+_See code: [src/commands/sync.ts](https://github.com/4746/figex/blob/v1.1.1/src/commands/sync.ts)_
 <!-- commandsstop -->
 
 
@@ -126,6 +126,7 @@ _See code: [src/commands/sync.ts](https://github.com/4746/figex/blob/v1.1.0/src/
   "nameExportType": "TSvg",
   "pathFileType": "dist/svg/svg.enum.ts",
   "pathFileSprite": "dist/svg/sprite-icons.svg"
+  // or dist/svg/sprite-icon-{hash}.svg
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cli107/figex",
   "description": "Figma export svg",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "Vadim",
   "keywords": [
     "figma-export",


### PR DESCRIPTION
…te filenames

Incremented project version to 1.1.1. Updated README to reflect new version links for commands. Introduced `simpleHash` utility to generate hashed filenames for SVG sprites, enhancing caching support.